### PR TITLE
colorcet 3.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colorcet" %}
-{% set version = "2.0.6" %}
-{% set sha256 = "efa44b6f4078261e62d0039c76aba17ac8d3ebaf0bc2291a111aee3905313433" %}
+{% set version = "3.0.0" %}
+{% set sha256 = "21c522346a7aa81a603729f2996c22ac3f7822f4c8c303c59761e27d2dfcf3db" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,15 +34,18 @@ test:
     - colorcet
 
 about:
-  home: http://github.com/pyviz/colorcet
+  home: https://colorcet.holoviz.org/index.html
   license: CC-BY-4.0
+  license_family: CC
+  license_url: https://github.com/holoviz/colorcet/blob/master/LICENSE.txt
   license_file: LICENSE.txt
   summary: Collection of perceptually uniform colormaps
   description: |
     colorcet is a collection of perceptually uniform colormaps for use with
     Python plotting programs like bokeh, matplotlib, holoviews, and datashader.
-  doc_url: https://pypi.python.org/pypi/colorcet
-  doc_source_url: https://github.com/bokeh/colorcet/blob/master/README.md
+  dev_url: https://github.com/pyviz/colorcet
+  doc_url: https://colorcet.holoviz.org/user_guide/index.html
+  doc_source_url: https://github.com/holoviz/colorcet/tree/master/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ about:
   description: |
     colorcet is a collection of perceptually uniform colormaps for use with
     Python plotting programs like bokeh, matplotlib, holoviews, and datashader.
-  dev_url: https://github.com/pyviz/colorcet
+  dev_url: https://github.com/holoviz/colorcet
   doc_url: https://colorcet.holoviz.org/user_guide/index.html
   doc_source_url: https://github.com/holoviz/colorcet/tree/master/doc
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,26 +12,28 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
-    - python >=2.7
+    - python
     - pip
     - setuptools >=30.3.0
     - param >=1.7.0
     - pyct >=0.4.4
     - wheel
-
   run:
-    - python >=2.7
+    - python
     - param >=1.7.0
     - pyct >=0.4.4
 
 test:
+  requires:
+    - pip
   imports:
     - colorcet
+  commands:
+    - pip check
 
 about:
   home: https://colorcet.holoviz.org/index.html


### PR DESCRIPTION
Update colorcet to 3.0.0

cb:
- Update metadata (home, license, dev_url, doc_url)
- Checked the requirements are still up-to-date.

See: 
https://github.com/holoviz/colorcet
https://github.com/holoviz/colorcet/blob/master/LICENSE.txt
https://github.com/holoviz/colorcet/blob/master/setup.py
https://colorcet.holoviz.org/

Concourse job: https://concourse.build.corp.continuum.io/teams/main/pipelines/cbousseau_colorcet