### PR TITLE
colorcet 3.2.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,23 @@
 {% set name = "colorcet" %}
-{% set version = "3.1.0" %}
-{% set sha256 = "2921b3cd81a2288aaf2d63dbc0ce3c26dcd882e8c389cc505d6886bf7aa9a4eb" %}
+{% set version = "3.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/{{ name }}/{{name}}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{name}}-{{ version }}.tar.gz
+  sha256: 48d9a67e6e59dc5c0a965aa1b46fe5d59cdc95cc36a95949f29313f950ac59f7
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - setuptools >=30.3.0
     - setuptools_scm >=6
     - wheel


### PR DESCRIPTION
colorcet 3.2.1 

**Destination channel:** Defaults

### Links

- [PKG-14377]
- dev_url:        https://github.com/holoviz/colorcet/tree/v3.2.1
- conda_forge:    https://github.com/conda-forge/colorcet-feedstock
- pypi:           https://pypi.org/project/colorcet/3.2.1
- pypi inspector: https://inspector.pypi.io/project/colorcet/3.2.1

### Explanation of changes:

- new version number


[PKG-14377]: https://anaconda.atlassian.net/browse/PKG-14377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ